### PR TITLE
Fix copy constructor issues, build all executables by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,15 @@ PROFILER_BIN = $(BIN_DIR)/profiler
 
 LIBRARY_SKVLR = $(LIBS_DIR)/skvlr.a
 
+EXECUTABLES = $(TEST_BIN) $(PROFILER_BIN)
+
 vpath % $(SRC_DIR) $(TEST_DIR) $(PROFILER_DIR)
+
+all: $(EXECUTABLES)
 
 $(LIBRARY_SKVLR): $(SKVLR_OBJS) | $(LIBS_DIR)
 	$(AR) $(LIBRARY_SKVLR) $(SKVLR_OBJS)
 	$(RANLIB) $(LIBRARY_SKVLR)
-
-all: $(LIBRARY_SKVLR)
 
 $(BIN_DIR):
 	@mkdir -p $@
@@ -48,7 +50,7 @@ $(OBJ_DIR)/%.o: %.cc
 	@echo + $@ [cc $<]
 	$(CC) $(CCFLAGS) -c $< -o $@ -c
 
-$(TEST_BIN): $(TEST_OBJS) $(SKVLR_OBJS) $(LIBRARY_SKVLR) | $(BIN_DIR)
+$(TEST_BIN): $(TEST_OBJS) $(LIBRARY_SKVLR) | $(BIN_DIR)
 	@echo + $@ [ld $^]
 	@$(CC) -o $@ $^ $(LDFLAGS)
 
@@ -57,11 +59,14 @@ test: $(TEST_BIN)
 	@-$(TEST_BIN)
 	@-pkill test
 
-$(PROFILER_BIN): $(PROFILER_OBJS) $(SKVLR_OBJS) $(LIBRARY_SKVLR) | $(BIN_DIR)
+$(PROFILER_BIN): $(PROFILER_OBJS) $(LIBRARY_SKVLR) | $(BIN_DIR)
 	@echo + $@ [ld $^]
 	@$(CC) -o $@ $^ $(LDFLAGS)
 
 profiler: $(PROFILER_BIN)
+	@-$(PROFILER_BIN)
+
+.PHONY: all clean
 
 clean:
-	rm $(LIBS_DIR)/* $(OBJ_DIR)/*
+	rm $(LIBS_DIR)/* $(OBJ_DIR)/* $(BIN_DIR)/*

--- a/include/skvlr.h
+++ b/include/skvlr.h
@@ -17,6 +17,10 @@ public:
     Skvlr(const std::string &name, int num_cores);
     ~Skvlr();
 
+    // Prevent assignment and copy constructors.
+    Skvlr & operator=(const Skvlr&) = delete;
+    Skvlr(const Skvlr&) = delete;
+
     // Blocking
     int db_get(const int key, int *value);
 

--- a/profiler/src/skvlr_profiler.cc
+++ b/profiler/src/skvlr_profiler.cc
@@ -26,7 +26,7 @@ void generate_keys(int num_keys, double mean, double stddev, std::vector<int> &k
   int key;
   for (int i = 0; i < num_keys; i++) {
     key = (int) distribution(generator);
-    keys.push_back(key);  
+    keys.push_back(key);
   }
 }
 
@@ -37,7 +37,7 @@ void generate_ops(std::vector<std::pair<int, int>> &ops) {
   generate_keys(NUM_GETS, 0, 1, get_keys);
   generate_keys(NUM_PUTS, 0, 1, put_keys);
   // TODO (kevinshin): Make get/put distinguishing cleaner
-  // TODO (kevinshin): Initialize all gets with values first (call put)  
+  // TODO (kevinshin): Initialize all gets with values first (call put)
   for(size_t i = 0; i < get_keys.size(); i++) {
     std::pair<int, int> pair(get_keys[i], -1);
     ops.push_back(pair);
@@ -55,16 +55,17 @@ void generate_ops(std::vector<std::pair<int, int>> &ops) {
 void run_ops(Skvlr *kv, const std::vector<std::pair<int, int>> ops) {
   for (size_t i = 0; i < ops.size(); i++) {
     if (ops[i].second == -1) {
-      kv->db_get(ops[i].first);
+      int val;
+      kv->db_get(ops[i].first, &val);
     } else {
       kv->db_put(ops[i].first, ops[i].second);
     }
-  } 
+  }
 }
 
 int main() {
   std::vector<std::vector<std::pair<int, int>>> client_thread_ops;
-  
+
   for (int i = 0; i < NUM_CORES; i++) {
     std::vector<std::pair<int, int>> ops;
     generate_ops(ops);
@@ -73,20 +74,20 @@ int main() {
   // Runs for: 1, 2, 4 ... NUM_CORES
   for (int kv_cores = 1; kv_cores <= NUM_CORES; kv_cores *= 2) {
     std::cout << "Core speeds for " << kv_cores << " processors: " << std::endl;
-    Skvlr kv = Skvlr("profiler_db", kv_cores); 
+    Skvlr kv("profiler_db", kv_cores);
     std::vector<std::thread> threads(NUM_CORES);
-  
+
     std::clock_t start = std::clock();
     for (int client_thread = 0; client_thread < NUM_CORES; client_thread++) {
       threads[client_thread] = std::thread(run_ops, &kv, client_thread_ops[client_thread]);
       // TODO (kevinshin): Set processor affinity. Also, should kv be passed by reference?
-    } 
+    }
     for (auto &thread : threads) {
       thread.join();
     }
 
     double duration = (std::clock() - start) / (double) CLOCKS_PER_SEC;
-    std::cout << "Duration: " << duration << std::endl; 
+    std::cout << "Duration: " << duration << std::endl;
     std::cout << "Number of operations: " << NUM_OPS << std::endl;
   }
   return 0;

--- a/src/skvlr.cc
+++ b/src/skvlr.cc
@@ -69,7 +69,7 @@ int Skvlr::db_get(const int key, int *value)
     uint32_t out;
 
     MurmurHash3_x86_32(&key, sizeof(int), 0, &out);
- 
+
     int curr_cpu = sched_getcpu();
     if(curr_cpu < 0)
         return -1;
@@ -77,7 +77,7 @@ int Skvlr::db_get(const int key, int *value)
     //synch_queue synch_queue = request_matrix[out % num_workers][curr_cpu];
     /* Construct request, enqueue request, down the semaphore. Return
        -1 or value based on response. */
-    
+
     //TODO: safely insert new request into proper queue
     //TODO: wait until request semaphore wakes you up
     //TODO: if request fails (req.STATUS == Skvlr::ERROR) return -1; else 0

--- a/test/src/skvlr_test.cc
+++ b/test/src/skvlr_test.cc
@@ -10,7 +10,7 @@ int main(int argc, const char *argv[]) {
 
 // put() random values, asserts that values are with consistent get() on a single core
 static bool test_valid_values() {
-  Skvlr test_kv = Skvlr("test_db", 1);
+  Skvlr test_kv("test_db", 1);
   for (int i = 0; i < 1000; i++) {
     test_kv.db_put(i, i);
   }


### PR DESCRIPTION
I tweaked a few things and set up our Makefile to automatically build both `/bin/test` and `/bin/profiler` so we don't accidentally break builds. You can also run `make test` or `make profiler` to build and invoke the executables directly so you don't have to remember the `bin` paths.

I also remove the copy constructor and assignment operator for `Skvlr` since copying a KV store doesn't make much sense when we manage threads internally.
