### PR TITLE
Workers persist puts and load from file on startup.

### DIFF
--- a/include/worker.h
+++ b/include/worker.h
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <fstream>
 #include <map>
 
 #include "skvlr.h"
@@ -9,18 +10,18 @@
 
 class Worker {
 public:
-    Worker(const int fd, const int worker_id, std::map<int, int> data);
     Worker(const Skvlr::worker_init_data init_data);
     ~Worker();
 
     void listen();
 
-private:
     void handle_get(Skvlr::request *req);
     void handle_put(Skvlr::request *req);
-    int persist(const int key, const int value);
 
-    const int fd;
-    const int worker_id;
+    int persist(const int key, const int value);
+    // TODO (RR): Make these methods private but testable.
+ private:
     std::map<int, int> data;
+    const Skvlr::worker_init_data worker_data;
+    std::ofstream outputLog;
 };

--- a/src/skvlr.cc
+++ b/src/skvlr.cc
@@ -36,7 +36,7 @@ Skvlr::Skvlr(const std::string &name, int num_workers)
 
     std::cout << "Spawning workers." << std::endl;
     for(int i = 0; i < num_workers; i++) {
-        worker_init_data init_data = {name, i, request_matrix[i], num_cores};
+        worker_init_data init_data(name, i, request_matrix[i], num_cores);
         workers[i] = std::thread(&spawn_worker, init_data);
     }
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,31 +1,24 @@
-
 #include <iostream>
 #include <assert.h>
 
 #include "worker.h"
 
-
-Worker::Worker(const int fd, const int worker_id, std::map<int, int> data)
-  : fd(fd), worker_id(worker_id), data(data)
-{
-    for (int i = 0; i < 5; ++i) {
-        std::cout << "I am worker " << worker_id << std::endl;
-        sleep(1);
-    }
-    UNUSED(this->fd);
-    UNUSED(this->worker_id);
-}
-
 // TODO: Change fd, worker_id values
 Worker::Worker(const Skvlr::worker_init_data init_data)
-  : fd(5), worker_id(5)
+    : worker_data(init_data), outputLog(init_data.dataFilePath(), std::ios::app)
 {
-  UNUSED(init_data);
+    // Read the contents of the data file if any and store it in `data`.
+    std::ifstream f(init_data.dataFilePath());
+    int key, value;
+    while (f >> key >> value) {
+        data[key] = value;
+    }
+    f.close();
 }
 
 Worker::~Worker()
 {
-    /* Empty */
+    outputLog.close();
 }
 
 /**
@@ -112,8 +105,7 @@ void Worker::handle_put(Skvlr::request *req)
  */
 int Worker::persist(const int key, const int value)
 {
-    (void) key;
-    (void) value;
-    // TODO: implement me!
-    return -1;
+    outputLog << key << '\t' << value << '\n' << std::flush;
+
+    return 0;
 }

--- a/test/src/skvlr_test.cc
+++ b/test/src/skvlr_test.cc
@@ -1,7 +1,9 @@
 #include <iostream>
+#include <fstream>
 #include <map>
 
 #include "skvlr.h"
+#include "worker.h"
 #include "test.h"
 
 int main(int argc, const char *argv[]) {
@@ -10,21 +12,112 @@ int main(int argc, const char *argv[]) {
 
 // put() random values, asserts that values are with consistent get() on a single core
 static bool test_valid_values() {
-  Skvlr test_kv("test_db", 1);
-  for (int i = 0; i < 1000; i++) {
-    test_kv.db_put(i, i);
-  }
-  for (int i = 0; i < 1000; i++) {
-    int value;
-    test_kv.db_get(i, &value);
-    check_eq(value, i);
-  }
-  return true;
+    Skvlr test_kv("test_db", 1);
+    for (int i = 0; i < 1000; i++) {
+        test_kv.db_put(i, i);
+    }
+    for (int i = 0; i < 1000; i++) {
+        int value;
+        test_kv.db_get(i, &value);
+        check_eq(value, i);
+    }
+    return true;
 }
+
+static bool prepare_worker_directory()
+{
+    check_eq(system("rm -rf worker"), 0);
+    check_eq(system("mkdir worker"), 0);
+    return true;
+}
+
+static bool test_worker_persistence_single() {
+    if (!prepare_worker_directory()) return false;
+
+    Skvlr::synch_queue q;
+    Skvlr::worker_init_data data("worker", 0, &q, 1);
+
+    Worker w(data);
+
+    w.persist(1, 2);
+
+    std::fstream outputFile(data.dataFilePath());
+    check(outputFile.good());
+
+    int key, value;
+    outputFile >> key >> value;
+    check_eq(key,   1);
+    check_eq(value, 2);
+    outputFile.close();
+
+    return true;
+}
+
+// Write a bunch of values and make sure that we can reconstruct them.
+static bool test_worker_persistence_map() {
+    if (!prepare_worker_directory()) return false;
+
+    Skvlr::synch_queue q;
+    Skvlr::worker_init_data data("worker", 0, &q, 1);
+    Worker w(data);
+    std::map<int, int> values;
+    for (int i = 0; i < 1000; ++i) {
+        values[i] = 2 * i;
+        w.persist(i, values[i]);
+    }
+
+    std::fstream outputFile(data.dataFilePath());
+    check(outputFile.good());
+
+    int key, value;
+    size_t num_values_seen = 0;
+    while (outputFile >> key >> value) {
+        check_eq(value, values[key]);
+        num_values_seen++;
+    }
+    check_eq(num_values_seen, values.size());
+    outputFile.close();
+
+    return true;
+}
+
+static bool test_worker_loads_from_file() {
+    if (!prepare_worker_directory()) return false;
+
+    // Write values to one worker.
+    Skvlr::synch_queue q;
+    Skvlr::worker_init_data data("worker", 0, &q, 1);
+    {
+        // Create a separate scope to invoke the worker destructor.
+        Worker w(data);
+        for (int i = 0; i < 1000; ++i) {
+            w.persist(i, 2 * i);
+        }
+    }
+
+    // Start a second worker in the same directory.
+    Worker secondWorker(data);
+    for (int i = 0; i < 1000; ++i) {
+        int value;
+        Skvlr::request req;
+        req.key = i;
+        req.value = &value;
+        req.type = Skvlr::RequestType::GET;
+        req.status = Skvlr::RequestStatus::PENDING;
+        secondWorker.handle_get(req);
+        check_eq(value, 2 * i);
+    }
+
+    return true;
+}
+
 
 // Time out value is set in test_utils.cc
 BEGIN_TEST_SUITE(sanity_checks) {
-  run_test(test_valid_values);
+    run_test(test_valid_values);
+    run_test(test_worker_persistence_single);
+    run_test(test_worker_persistence_map);
+    run_test(test_worker_loads_from_file);
 }
 
 BEGIN_TESTING {


### PR DESCRIPTION
I added support for persistence in the workers. They now read from the file `dir_name/worker_id.data` on startup and append to it as new `put`s arrive. They don't do any fancy cleaning or compacting. I added some tests to verify that the `persist` methods write to files and that the constructor re-reads the saved data.
